### PR TITLE
Support Stsfld opcode when reading constants.

### DIFF
--- a/src/OldRod.Pipeline/Stages/ConstantsResolution/ConstantsResolutionStage.cs
+++ b/src/OldRod.Pipeline/Stages/ConstantsResolution/ConstantsResolutionStage.cs
@@ -202,7 +202,7 @@ namespace OldRod.Pipeline.Stages.ConstantsResolution
             {
                 if (instruction.IsLdcI4())
                     nextValue = (byte) instruction.GetLdcI4Constant();
-                else if (instruction.OpCode.Code == CilCode.Stfld)
+                else if (instruction.OpCode.Code == CilCode.Stfld || instruction.OpCode.Code == CilCode.Stsfld)
                     result[(FieldDefinition) instruction.Operand] = nextValue;
             }
 


### PR DESCRIPTION
Some mod makers have caught on and realized they can just use `stsfld` instead of the `ldnull` + `stfld` combo of the original KoiVM.