### PR TITLE
Fix TypeReferences emitted by OldRod using incorrect CorLib.

### DIFF
--- a/src/OldRod.Core/CodeGen/CilCodeGenerator.cs
+++ b/src/OldRod.Core/CodeGen/CilCodeGenerator.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using OldRod.Core.Architecture;
 using OldRod.Core.Ast.Cil;
@@ -276,7 +277,14 @@ namespace OldRod.Core.CodeGen
                     x.Name == nameof(VmHelper.ConvertToVmType)
                     && x.Parameters.Count == 2);
                 
-                var typeFromHandle = _context.ReferenceImporter.ImportMethod(typeof(Type).GetMethod("GetTypeFromHandle"));
+                var scope = _context.TargetModule.CorLibTypeFactory.CorLibScope;
+
+                var typeRef = new TypeReference(_context.TargetModule, scope, "System", "Type");
+                var rtTypeHandleRef = new TypeReference(_context.TargetModule, scope, "System", "RuntimeTypeHandle");
+                var methodRef = new MemberReference(typeRef, "GetTypeFromHandle",
+                    MethodSignature.CreateStatic(typeRef.ToTypeSignature(), rtTypeHandleRef.ToTypeSignature()));
+
+                var typeFromHandle = _context.ReferenceImporter.ImportMethod(methodRef);
                 result.AddRange(new[]
                 {
                     new CilInstruction(CilOpCodes.Ldtoken, expression.Type),

--- a/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
+++ b/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
@@ -70,7 +70,7 @@ namespace OldRod.Core.CodeGen
             {
                 var defAsm = type.Scope?.GetAssembly();
                 if (defAsm is not null && defAsm.IsCorLib)
-                    type = new TypeReference(Context.Module, TargetModule.CorLibTypeFactory.CorLibScope, type.Namespace, type.Name);
+                    return new TypeReference(Context.Module, TargetModule.CorLibTypeFactory.CorLibScope, type.Namespace, type.Name);
                 return base.ImportType(type);
             }
         }

--- a/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
+++ b/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
@@ -60,11 +60,14 @@ namespace OldRod.Core.CodeGen
             return flagHelperType;
         }
 
-        private sealed class UseExistingCorlibReferenceImporter : CloneContextAwareReferenceImporter {
-            internal UseExistingCorlibReferenceImporter(MemberCloneContext context)
-                : base(context) { }
+        private sealed class UseExistingCorlibReferenceImporter : CloneContextAwareReferenceImporter
+        {
+            internal UseExistingCorlibReferenceImporter(MemberCloneContext context) : base(context) 
+            {
+            }
 
-            protected override ITypeDefOrRef ImportType(TypeReference type) {
+            protected override ITypeDefOrRef ImportType(TypeReference type)
+            {
                 var defAsm = type.Scope?.GetAssembly();
                 if (defAsm is not null && defAsm.IsCorLib)
                     type = new TypeReference(Context.Module, TargetModule.CorLibTypeFactory.CorLibScope, type.Namespace, type.Name);

--- a/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
+++ b/src/OldRod.Core/CodeGen/VmHelperGenerator.cs
@@ -35,7 +35,7 @@ namespace OldRod.Core.CodeGen
         public static TypeDefinition ImportFlagHelper(ModuleDefinition module, VMConstants constants)
         {
             // Clone flag helper class.
-            var cloner = new MemberCloner(module);
+            var cloner = new MemberCloner(module, context => new UseExistingCorlibReferenceImporter(context));
             cloner.Include(VmHelperType);
             var result = cloner.Clone();
             var flagHelperType = result.ClonedMembers.OfType<TypeDefinition>().First();
@@ -58,6 +58,18 @@ namespace OldRod.Core.CodeGen
             instructions.Add(new CilInstruction(CilOpCodes.Ret));
 
             return flagHelperType;
+        }
+
+        private sealed class UseExistingCorlibReferenceImporter : CloneContextAwareReferenceImporter {
+            internal UseExistingCorlibReferenceImporter(MemberCloneContext context)
+                : base(context) { }
+
+            protected override ITypeDefOrRef ImportType(TypeReference type) {
+                var defAsm = type.Scope?.GetAssembly();
+                if (defAsm is not null && defAsm.IsCorLib)
+                    type = new TypeReference(Context.Module, TargetModule.CorLibTypeFactory.CorLibScope, type.Namespace, type.Name);
+                return base.ImportType(type);
+            }
         }
     }
 }

--- a/src/OldRod.Core/Recompiler/Transform/TypeHelper.cs
+++ b/src/OldRod.Core/Recompiler/Transform/TypeHelper.cs
@@ -38,8 +38,8 @@ namespace OldRod.Core.Recompiler.Transform
             var factory = ownerModule.CorLibTypeFactory;
             var scope = ownerModule.CorLibTypeFactory.CorLibScope;
 
-            _arrayType = importer.ImportType(new TypeReference(ownerModule, scope, "System", "Array"));
-            _objectType = importer.ImportType(new TypeReference(ownerModule, scope, "System", "Object"));
+            _arrayType = new TypeReference(ownerModule, scope, "System", "Array");
+            _objectType = new TypeReference(ownerModule, scope, "System", "Object");
 
             _signedIntegralTypes = new TypeSignature[]
             {

--- a/src/OldRod.Core/Recompiler/Transform/TypeHelper.cs
+++ b/src/OldRod.Core/Recompiler/Transform/TypeHelper.cs
@@ -34,13 +34,13 @@ namespace OldRod.Core.Recompiler.Transform
 
         public TypeHelper(ReferenceImporter importer)
         {
-            var scope = importer.TargetModule.CorLibTypeFactory.CorLibScope;
+            var ownerModule = importer.TargetModule;
+            var factory = ownerModule.CorLibTypeFactory;
+            var scope = ownerModule.CorLibTypeFactory.CorLibScope;
 
-            _arrayType = importer.ImportType(new TypeReference(scope, "System", "Array"));
-            _objectType = importer.ImportType(new TypeReference(scope, "System", "Object"));
+            _arrayType = importer.ImportType(new TypeReference(ownerModule, scope, "System", "Array"));
+            _objectType = importer.ImportType(new TypeReference(ownerModule, scope, "System", "Object"));
 
-            var factory = importer.TargetModule.CorLibTypeFactory;
-            
             _signedIntegralTypes = new TypeSignature[]
             {
                 factory.SByte,

--- a/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
+++ b/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
@@ -19,7 +19,7 @@ namespace OldRod.Core.Recompiler.VCall
             var argument = (CilExpression) expression.Arguments[2].AcceptVisitor(context.Recompiler);
 
             var scope = context.TargetModule.CorLibTypeFactory.CorLibScope;
-            argument.ExpectedType = context.ReferenceImporter.ImportType(new TypeReference(context.TargetModule, scope, "System", "Exception"));
+            argument.ExpectedType = new TypeReference(context.TargetModule, scope, "System", "Exception");
             
             var result = new CilInstructionExpression(CilOpCodes.Throw,
                 null,

--- a/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
+++ b/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
@@ -1,4 +1,5 @@
 using System;
+using AsmResolver.DotNet;
 using AsmResolver.PE.DotNet.Cil;
 using OldRod.Core.Ast.Cil;
 using OldRod.Core.Ast.IL;
@@ -16,7 +17,9 @@ namespace OldRod.Core.Recompiler.VCall
                 return new CilInstructionExpression(CilOpCodes.Rethrow);
 
             var argument = (CilExpression) expression.Arguments[2].AcceptVisitor(context.Recompiler);
-            argument.ExpectedType = context.ReferenceImporter.ImportType(typeof(Exception));
+
+            var scope = context.TargetModule.CorLibTypeFactory.CorLibScope;
+            argument.ExpectedType = context.ReferenceImporter.ImportType(new TypeReference(context.TargetModule, scope, "System", "Exception"));
             
             var result = new CilInstructionExpression(CilOpCodes.Throw,
                 null,


### PR DESCRIPTION
The previous method would create references to `netstndard` instead of `mscorlib` for .NET Framework executables. 

This does not prevent this problem from occurring when injecting the VmHelper type since the importing there is done by AsmResolver and it doesn't offer any way to easily change these references to the correct core library when injecting. In theory, OldRod could iterate over the injected members to patch the references but that seems rather hacky.