### PR TITLE
Fix recompilation of `rethrow` OpCode

### DIFF
--- a/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
+++ b/src/OldRod.Core/Recompiler/VCall/ThrowRecompiler.cs
@@ -12,10 +12,13 @@ namespace OldRod.Core.Recompiler.VCall
         {
             var annotation = (ThrowAnnotation) expression.Annotation;
 
+            if (annotation.IsRethrow)
+                return new CilInstructionExpression(CilOpCodes.Rethrow);
+
             var argument = (CilExpression) expression.Arguments[2].AcceptVisitor(context.Recompiler);
             argument.ExpectedType = context.ReferenceImporter.ImportType(typeof(Exception));
             
-            var result = new CilInstructionExpression(annotation.IsRethrow ? CilOpCodes.Rethrow :  CilOpCodes.Throw,
+            var result = new CilInstructionExpression(CilOpCodes.Throw,
                 null,
                 argument);
 


### PR DESCRIPTION
The old implementation treated `rethrow` OpCode as if it had the same stack behavior as `throw`. This was incorrect as `rethrow` does not pop anything from the stack unlike `throw` which does.