### PR TITLE
Fix disassembly of `filter` region

### DIFF
--- a/src/OldRod.Core/Disassembly/Inference/InstructionProcessor.cs
+++ b/src/OldRod.Core/Disassembly/Inference/InstructionProcessor.cs
@@ -274,6 +274,10 @@ namespace OldRod.Core.Disassembly.Inference
                 var filterState = next.Copy();
                 filterState.Key = 0;
                 filterState.IP = frame.FilterAddress;
+                filterState.IgnoreExitKey = true;
+                filterState.Stack.Push(new SymbolicValue(
+                    new ILInstruction(PushExceptionOffset, ILOpCodes.__PUSH_EXCEPTION, null),
+                    VMType.Object));
                 result.Add(filterState);
             }
 

--- a/src/OldRod.Core/Emulation/InstructionEmulator.cs
+++ b/src/OldRod.Core/Emulation/InstructionEmulator.cs
@@ -61,10 +61,17 @@ namespace OldRod.Core.Emulation
                     });
                     break;
                 }
-                case ILCode.PUSHR_QWORD:
+                case ILCode.PUSHR_BYTE:
                     Stack.Push(new VMSlot
                     {
-                        U8 = Registers[(VMRegisters) instruction.Operand].U8
+                        U1 = Registers[(VMRegisters) instruction.Operand].U1
+                    });
+                    break;
+              
+                case ILCode.PUSHR_WORD:
+                    Stack.Push(new VMSlot
+                    {
+                        U2 = Registers[(VMRegisters) instruction.Operand].U2
                     });
                     break;
                 
@@ -75,12 +82,26 @@ namespace OldRod.Core.Emulation
                     });
                     break;
                 
+                case ILCode.PUSHR_QWORD:
+                    Stack.Push(new VMSlot
+                    {
+                        U8 = Registers[(VMRegisters) instruction.Operand].U8
+                    });
+                    break;
+
                 case ILCode.PUSHI_DWORD:
                     uint imm = Convert.ToUInt32(instruction.Operand);
                     ulong sx = (imm & 0x80000000) != 0 ? 0xffffffffUL << 32 : 0;
                     Stack.Push(new VMSlot
                     {
                         U8 = sx | imm
+                    });
+                    break;
+                
+                case ILCode.PUSHI_QWORD:
+                    Stack.Push(new VMSlot
+                    {
+                        U8 = Convert.ToUInt64(instruction.Operand)
                     });
                     break;
 
@@ -111,6 +132,9 @@ namespace OldRod.Core.Emulation
                     Registers[(VMRegisters) instruction.Operand] = Stack.Pop();
                     break;
                 }
+                
+                case ILCode.NOP:
+                    break;
                 
                 default:
                     throw new EmulationException($"Failed to emulate the instruction {instruction}.",


### PR DESCRIPTION
Fixes disassembly for `filter` region of an exception handler.

refs #53