### PR TITLE
Add support for disassembling code which had KoiVM's SMC transform applied

### DIFF
--- a/src/OldRod.Core/Disassembly/Inference/VMFunction.cs
+++ b/src/OldRod.Core/Disassembly/Inference/VMFunction.cs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
+using AsmResolver;
 using OldRod.Core.Architecture;
 using OldRod.Core.Disassembly.ControlFlow;
 using OldRod.Core.Memory;
@@ -70,6 +71,18 @@ namespace OldRod.Core.Disassembly.Inference
         {
             get;
         } = new HashSet<FunctionReference>();
+        
+        public byte SMCTrampolineKey 
+        {
+            get;
+            set;
+        }
+
+        public OffsetRange SMCTrampolineOffsetRange 
+        {
+            get;
+            set;
+        }
 
         public override string ToString()
         {


### PR DESCRIPTION
The open source release of KoiVM includes a feature that is not enabled by default which aims to make disassembly harder. It does this by introducing self-modying code. It works by inserting a special prologue to the function body. The prologue is partially encrypted and the decryption is handled at runtime.
Pseudocode of the prologue code:
```cs
EntryStub:
{
    counter = TrampolineBlockLength;
    pointer = &Trampoline;
    pointer -= 1;
    t1 = *pointer;
    if (t1 == 0) {
        goto Trampoline;
    }
    if (counter != 0) {
        goto LoopBody;
    }
    t3 = &RealEntry;
    goto Trampoline;
}

LoopBody:
{
    t2 = *pointer;
    t2 ^= TrampolineCodeKey;
    *pointer = t2;
    counter -= 1;
    pointer += 1;
    if (counter != 0) {
        goto LoopBody;
    }
    t3 = &RealEntry;
    goto Trampoline;
}

Trampoline:
{
    t3 ^= AddressKey;
    goto RealEntry;
}

RealEntry:
{
    // Some code here
}
```
The code in the `Trampoline` block in the above Pseudocode is decrypted at runtime inside `LoopBody`.

<details>
<summary>Control flow graph of the raw disassembled code (User code starts at IL_11B1)</summary>
<img src="https://user-images.githubusercontent.com/37494960/186896465-d16ef5eb-afba-4fea-96ca-5e263b64b0aa.svg" /> 
</details>

After these changes, OldRod is able to fully disassemble code that had the aforementioned transform applied. However, the output of the devirtualization does not run due to the inclusion of the of the translated SMC prologue as can be seen in the image below:
![image](https://user-images.githubusercontent.com/37494960/186897307-c27aff41-dc69-4af7-b032-d68bb3b2e350.png)
The user code begins with the call to `Application.EnableVisualStyles();`.
