### PR TITLE
Update AsmResolver and other NuGet packages

### DIFF
--- a/src/OldRod.Core/OldRod.Core.csproj
+++ b/src/OldRod.Core/OldRod.Core.csproj
@@ -17,6 +17,6 @@
     <ProjectReference Include="$(SolutionDir)\deps\Rivers\Rivers\Rivers.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsmResolver.DotNet" Version="4.11.2" />
+    <PackageReference Include="AsmResolver.DotNet" Version="5.4.0" />
   </ItemGroup>
 </Project>

--- a/src/OldRod.Pipeline/Devirtualiser.cs
+++ b/src/OldRod.Pipeline/Devirtualiser.cs
@@ -237,13 +237,14 @@ namespace OldRod.Pipeline
             ModuleDefinition module,
             string fileName)
         {
-            var imageBuilder = new ManagedPEImageBuilder();
+            var diagnosticBag = new DiagnosticBag();
+            var imageBuilder = new ManagedPEImageBuilder(diagnosticBag);
 
             var result = imageBuilder.CreateImage(module);
-            if (result.DiagnosticBag.IsFatal)
-                throw new AggregateException(result.DiagnosticBag.Exceptions);
+            if (diagnosticBag.IsFatal)
+                throw new AggregateException(diagnosticBag.Exceptions);
 
-            foreach (var error in result.DiagnosticBag.Exceptions)
+            foreach (var error in diagnosticBag.Exceptions)
                 context.Logger.Error(Tag, error.Message);
 
             var fileBuilder = new ManagedPEFileBuilder();

--- a/src/OldRod.Pipeline/KoiVmAwareStreamReader.cs
+++ b/src/OldRod.Pipeline/KoiVmAwareStreamReader.cs
@@ -17,7 +17,6 @@
 using System;
 using AsmResolver;
 using AsmResolver.IO;
-using AsmResolver.PE;
 using AsmResolver.PE.DotNet.Metadata;
 using OldRod.Core;
 using OldRod.Core.Architecture;
@@ -50,7 +49,7 @@ namespace OldRod.Pipeline
             get;
         }
 
-        public IMetadataStream ReadStream(PEReaderContext context, MetadataStreamHeader header, ref BinaryStreamReader reader)
+        public IMetadataStream ReadStream(MetadataReaderContext context, MetadataStreamHeader header, ref BinaryStreamReader reader)
         {
             return header.Name == KoiStreamName
                 ? new KoiStream(KoiStreamName, new DataSegment(reader.ReadToEnd()), Logger)

--- a/src/OldRod.Pipeline/Stages/VMMethodDetection/VMMethodDetectionStage.cs
+++ b/src/OldRod.Pipeline/Stages/VMMethodDetection/VMMethodDetectionStage.cs
@@ -28,10 +28,7 @@ namespace OldRod.Pipeline.Stages.VMMethodDetection
 {
     public class VMMethodDetectionStage : IStage
     {
-        private static readonly SignatureComparer Comparer = new SignatureComparer
-        {
-            IgnoreAssemblyVersionNumbers = true
-        };
+        private static readonly SignatureComparer Comparer = new SignatureComparer(SignatureComparisonFlags.VersionAgnostic);
 
         public const string Tag = "VMMethodDetection";
         

--- a/src/OldRod/OldRod.csproj
+++ b/src/OldRod/OldRod.csproj
@@ -17,9 +17,9 @@
       <ProjectReference Include="..\OldRod.Pipeline\OldRod.Pipeline.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/OldRod/Program.cs
+++ b/src/OldRod/Program.cs
@@ -37,7 +37,7 @@ namespace OldRod
         
         private static void PrintAbout()
         {
-            if (Console.BufferHeight > 43)
+            if (Console.BufferHeight - Console.CursorTop > 43)
                 WriteAlignedAbout();
             else
                 WriteFallbackAbout();


### PR DESCRIPTION
System.Drawing.Common 7.0.0 shows a compiler warning regarding the lack of support for .NET Core 3.1 so it was upgraded to 6.0.0 which does not show such a warning.

A small fix was introduced for a crash that occurred when running OldRod in the Windows Terminal when the remaining buffer space was not enough for the aligned screen.